### PR TITLE
add sticky footer component

### DIFF
--- a/index.css
+++ b/index.css
@@ -185,3 +185,24 @@ a {
   text-decoration: none;
   margin: 0 50px;
 }
+footer {
+  border-top: 2px solid #00ff00;
+  padding-top: 20px;
+  text-align: center;
+  position: relative;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  color: #e98e1b;
+  margin: auto;
+  padding: 0 20px 20px;
+  background-color: #0A01A7;
+  /* space between content and footer */
+  margin-top: 20px;
+}
+
+.footer-text{
+  color: #e98e1b;
+  text-align: center;
+}
+

--- a/index.html
+++ b/index.html
@@ -51,5 +51,13 @@
                 frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
         </div>
         <img style="max-width:100%;height:auto;margin-top:10%" src="./homePage/img/gallery.png" />
+
+        <footer class="footerInner">
+            <p class="footer-text">
+            © 2021 Made with &hearts; by <br/><a style="color: #00ff00" href="https://gmcruz.me/debugs-bunnies/">DebugsBunnies POD 2.0.3 </a>  
+            </p>    
+        </footer>
+    </div>
+    
     </body>
 </html>


### PR DESCRIPTION
Added as an independent component in the `footer/` folder.
The css handling the footer component has been added to the main index.css file
To use the component, the main index.js will import it and in the render function, use `<Footer />`
This solves issue #9 